### PR TITLE
Updates and Refactoring

### DIFF
--- a/aio-enum.sh
+++ b/aio-enum.sh
@@ -9,10 +9,19 @@ BLUE="\033[01;34m"
 BOLD="\033[01;01m"
 RESET="\033[00m"
 
-# sources
-source ./nmap-nse-scans.sh
-source ./discovery-scans.sh
-source ./parsers.sh
+# defaults
+TCPPORTRANGE=1-65535
+UDPPORTRANGE=53,69,123,161,500,1434
+MINRATE=200
+MINHOST=500
+MAXRATE=500
+SCANTYPE=help
+TOOLSINSTALLED=1
+OUTPUTDIR="$(pwd)/$(date +'%Y%m%d%H%M%S')"
+
+# Sources
+SCRIPTDIR=$(dirname "$0")
+source "$SCRIPTDIR/getopts-long.sh"
 
 #-- check for root or exit
 if [ $EUID != 0 ]
@@ -29,41 +38,65 @@ do
     #echo ${tool[*]}
     if ! which "$tool" > /dev/null
     then
-	echo -e "\n[${RED}!${RESET}] $tool ${RED}not${RESET} found"
+	    echo -e "\n[${RED}!${RESET}] $tool ${RED}not${RESET} found"
+	    TOOLSINSTALLED=0
+    fi
+done
+if [ $TOOLSINSTALLED != 1 ]
+then
 	echo -e "\n[${RED}!${RESET}] Ensure the following tools are installed: ${tools[*]}"
 	exit 1
-    fi
-done
-# populate files and folders
-declare -a files=("./targets.ip" "./exclude.ip")
-declare -a folders=("scans" "open-ports" "nse_scans" "masscan/scans/" "nmap/scans/")
+fi
 
-for file in ${files[*]}
-do
-    if [ ! -f "$file" ]
-    then
-	touch $file
-        echo -e "\n[${GREEN}+${RESET}] Populate the ${YELLOW} $file ${RESET} file"
-	exit 1
-    fi
-done
+setup(){
+	# sources
+	source "$SCRIPTDIR/nmap-nse-scans.sh"
+	source "$SCRIPTDIR/discovery-scans.sh"
+	source "$SCRIPTDIR/parsers.sh"
 
-for folder  in ${folders[*]}
-do
-    if [ ! -d "$folder" ]
-    then
-	mkdir -p $folder
-    fi
-done
+	# populate files and folders
+	declare -a files=("./targets.ip" "./exclude.ip")
+	declare -a folders=("scans" "open-ports" "nse_scans" "masscan/scans/" "nmap/scans/")
+
+	for file in ${files[*]}
+	do
+		if [ ! -f "$file" ]
+		then
+			touch $file
+			echo -e "\n[${GREEN}+${RESET}] Populate the ${YELLOW} $file ${RESET} file"
+			exit 1
+		fi
+	done
+
+	for folder  in ${folders[*]}
+	do
+		if [ ! -d "$OUTPUTDIR/$folder" ]
+		then
+			mkdir -p "$OUTPUTDIR/$folder"
+		fi
+	done
+
+	# Check targets.ip isn't empty
+	if [ ! -s targets.ip ]
+	then
+		echo -e "\n [${RED}!${RESET}] targets.ip file isn't populated with target IP addresses"
+		exit 1
+	fi
+}
 
 # Your IP Address
 ipChecker(){
     echo -e "\n ${RED}[!] ENSURE YOU ARE SOURCING FROM AN INSCOPE IP" ${RESET}
     pubIP=$(curl -s https://ifconfig.me | cut -d '%' -f1)
     echo -e "\nYour Public IP is: " ${RED}$pubIP${RESET}
-    intIP=$(ip -o -4 addr list | awk ' {print $4}' | cut -d/ -f1)
+    intIP=$(ip -o -4 addr list | grep -v '127.0.0.1'| awk ' {print $4}' | cut -d/ -f1)
     echo -e "\nYour Internal IP(s) are: " ${RED}$intIP${RESET}
-    read -p "Press Enter to continue"
+	echo -e "\n ${RED}[!] Ctrl+c${RESET} now if you do not want to proceed"
+	for i in {5..1}
+	do
+		echo -ne "Continuing in ${RED}$i${RESET}\033[0K\r"
+		sleep 1
+	done
 }
 
 ######################## Help
@@ -80,111 +113,146 @@ help(){
 	echo "-7| --csv)     Nmap XML to CSV"
 	echo "-h| --help)    Print this help"
 	echo "-v| --version) Print version and exit"
+	echo ""
+	echo "--tcpportrange TCP Ports for scanning in nmap format, e.g. 1-1024,8080,8443. Default is all ports"
+	echo "--udpportrange UDP ports for scanning in nmap format, e.g. 161,500. default is 53,69,123,161,500,1434"
+	echo "--nmap-minhost Minimum hostgroup size for nmap. Default value is 500"
+	echo "--nmap-minrate Minimum rate for nmap. Default value is 200"
+	echo "--masscan-maxrate Maximum rate for masscan. Default value is 500"
+	echo "--masscan-interface Network interface that masscan should use"
+	echo "--outputdir    Output directory for all files"
 }
 
-# Transform long options to short ones (getopts wont parse)
-for arg in "$@"; do
-    shift
-    case "$arg" in
-      "--help") set -- "$@" "-h" ;;
-      "--default") set -- "$@" "-1" ;;
-      "--quick") set -- "$@" "-2" ;;
-      "--scans") set -- "$@" "-3" ;;
-      "--all") set -- "$@" "-4" ;;
-      "--nmap") set -- "$@" "-5" ;;
-      "--icmp") set -- "$@" "-6" ;;
-      "--csv") set -- "$@" "-7" ;;
-      "--version") set -- "$@" "-v" ;;
-      *)        set -- "$@" "$arg"
+declare -A longopts=([help]='' [default]='' [quick]='' [scans]='' [all]='' [nmap]='' [icmp]='' [csv]='' [version]='' [tcpportrange]=: [udpportrange]=: [nmap-minhost]=: [nmap-minrate]=: [masscan-maxrate]=: [masscan-interface]=: [outputdir]=:)
+while getopts_long longopts h1234567v opt "$@"; do
+    case "$opt" in
+	    help|h)
+		    SCANTYPE=help;;
+		tcpportrange)
+			TCPPORTRANGE=$OPTARG;;
+		udpportrange)
+			UDPPORTRANGE=$OPTARG;;
+		nmap-minhost)
+			MINHOST=$OPTARG;;
+		nmap-minrate)
+			MINRATE=$OPTARG;;
+		masscan-maxrate)
+			MAXRATE=$OPTARG;;
+		masscan-interface)
+			MASSCANINTERFACE=$OPTARG;;
+		outputdir)
+			OUTPUTDIR=$OPTARG;;
+		default|1) 
+			echo "[1] selected, running a PingSweep and Portscan on all targets"
+			SCANTYPE=default;;
+		quick|2) 
+			echo "[2] selected, running Portscans on hosts that reply to ICMP"
+			SCANTYPE=quick;;
+		scans|3)
+			echo "[3] selected, running -- Masscan|Nmap|NSEs"
+			SCANTYPE=scans;;
+		all|4)
+			echo "[4] selected, running -- Masscan | Nmap | NSEs | Dictionary attacks!"
+			SCANTYPE=all;;
+		nmap|5)
+			echo "[5] selected, running -- Nmap|NSEs"
+			SCANTYPE=nmap;;
+		icmp|6)
+			echo "[6] nmap pingsweep only"
+			SCANTYPE=icmp;;
+		csv|7)
+			echo "[7] Nmap to CSV"
+			SCANTYPE=csv;;
+		version|v) 
+			echo "version 1.2"
+		    exit;;
+		*) 
+			echo -e "Error: Invalid option\n"
+	    	echo "Usage: ./aio-enum.sh [-h | --help]"
+	    	exit 1;;
     esac
 done
 
-#OPTIND=1 
-# getopts to parse options
-while getopts ":h1234567v" flag; do
-    case "${flag}" in
-	h) #display help
-	    help
-	    exit;;
-	1)  echo "[1] selected, running a PingSweep and Portscan on all targets"
-	    ipChecker
-	    nmapSettings
-	    masscanResolver
-	    massscanPortScan
-	    pingSweep
-	    nmapAllHostsPortScan
-	    combiner
-	    parser
-	    summary;;
-	2)  echo "[2] selected, running Portscans on hosts that reply to ICMP"
-            ipChecker
-	    nmapSettings
-	    masscanResolver
-            massscanPortScan
-            pingSweep
-            nmapPortScan
-            combiner
-            parser
-            summary;;
-	3)  echo "[3] selected, running -- Masscan|Nmap|NSEs"
-	    ipChecker
-	    nmapSettings
-	    masscanResolver
-	    massscanPortScan
-	    pingSweep
-	    nmapPortScan
-	    combiner
-	    parser
-	    nse
-	    otherScans
-	    summary;;
-	4)  echo "[4] selected, running -- Masscan | Nmap | NSEs | Dictionary attacks!"
-	    ipChecker
-	    nmapSettings
-	    masscanResolver
-	    massscanPortScan
-	    pingSweep
-	    nmapPortScan
-	    combiner
-	    parser
-	    nse
-	    otherScans
-	    discoveryScans # for dictionary attacks
-	    summary;;
-	5)  echo "[5] selected, running -- Nmap|NSEs"
-	    ipChecker
-	    nmapSettings
-	    pingSweep
-	    nmapPortScan
-	    combiner
-	    parser
-	    nse
-	    otherScans
-	    summary;;
-	6)  echo "[6] nmap pingsweep only"
-	    ipChecker
-	    pingSweep
-	    summaryPingSweep;;
-	7)  echo "[7] Nmap to CSV"
-	    csvParser;;
-	v)  echo "version 1.2"
-	    exit;;
-	*)  echo -e "Error: Invalid option\n"
-	    echo "Usage: ./aio-enum.sh [-h | --help]"
-	    exit 1;;
-    esac
-done
-#shift $(expr $OPTIND - 1)
+case $SCANTYPE in
+	help)
+		help
+		exit;;
+	default)
+		setup
+		ipChecker
+		nmapSettings
+		massscanPortScan
+		pingSweep
+		nmapAllHostsPortScan
+		combiner
+		parser
+		summary;;
+	quick)
+		setup
+		ipChecker
+		nmapSettings
+		massscanPortScan
+		pingSweep
+		nmapPortScan
+		combiner
+#		parser
+		summary;;
+	scans)
+		setup
+		ipChecker
+		nmapSettings
+		massscanPortScan
+		pingSweep
+		nmapPortScan
+		combiner
+		parser
+		nse
+		otherScans
+		summary;;
+	all)
+		setup
+		ipChecker
+		nmapSettings
+		massscanPortScan
+		pingSweep
+		nmapPortScan
+		combiner
+		parser
+		nse
+		otherScans
+		discoveryScans # for dictionary attacks
+		summary;;
+	nmap)
+		setup
+		ipChecker
+		nmapSettings
+		pingSweep
+		nmapPortScan
+		combiner
+		parser
+		nse
+		otherScans
+		summary;;
+	icmp)
+		setup
+		ipChecker
+		pingSweep
+		summaryPingSweep;;
+	csv)
+		setup
+		csvParser;;
+esac
 
 if [ "$#" == "0" ]; then
 	echo -e "\n[+] No options provided!"
-	echo -e "Executing ICMP pingsweep & portscan..."
-	ipChecker
-	MINHOST=50
-	MINRATE=500
-	PORTRANGE=1-65535
-	pingSweep
-	summaryPingSweep
-	nmapPortScan
-	summary
+	help
+#	echo -e "Executing ICMP pingsweep & portscan..."
+#	ipChecker
+#	MINHOST=50
+#	MINRATE=500
+#	PORTRANGE=1-65535
+#	pingSweep
+#	summaryPingSweep
+#	nmapPortScan
+#	summary
 fi

--- a/discovery-scans.sh
+++ b/discovery-scans.sh
@@ -1,62 +1,37 @@
 #-- scan functions
 # Arguments
 nmapSettings(){
-    PORTANGE=
-    if  [[ -z "$PORTRANGE" ]]; then
-        read -p "[!] Set TCP port range (1-65535): " PORTRANGE
-    fi
-    if [[ -z "$PORTRANGE" ]];
-    then
-        PORTRANGE=1-65535
-    fi
-    MINHOST=
-    if  [[ -z "$MINHOST" ]]; then
-        read -p "[!] Set Nmap value for --min-host (50): " MINHOST
-    fi
-    if [[ -z "$MINHOST" ]];
-    then
-        MINHOST=500
-    fi
-    MINRATE=
-    if  [[ -z "$MINRATE" ]]; then
-        read -p "[!] Set Nmap value for --min-rate (200): " MINRATE
-    fi
-    if [[ -z "$MINRATE" ]];
-    then
-        MINRATE=200
-    fi
+    echo -e "\n[${GREEN}+${RESET}] Using nmap settings:\n    tcp port range: ${GREEN}${TCPPORTRANGE}${RESET}\n    udp port range: ${GREEN}${UDPPORTRANGE}${RESET}\n    minimum host group: ${GREEN}${MINHOST}${RESET}\n    minimum rate: ${GREEN}${MINRATE}${RESET}"
 }
+
 #-- masscan
 masscanResolver(){
+    echo -e "\n[${GREEN}+${RESET}] Using masscan settings:\n    tcp port range: ${GREEN}${TCPPORTRANGE}${RESET}\n    udp port range: ${GREEN}${UDPPORTRANGE}${RESET}\n    max rate: ${GREEN}${MAXRATE}${RESET}"
     echo -e "\n[${GREEN}+${RESET}] Running ${YELLOW}masscan${RESET} scans"
     echo -e "\n[${GREEN}+${RESET}] Resolving all ${YELLOW}hostnames${RESET} in targets.ip"
     for item in $(cat ./targets.ip);
     do
         if [[ $item =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]] || [[ $item =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\/[0-9]{1,2}$ ]];
         then
-            echo $item >> masscan/resolv.ip
+            echo $item >> "$OUTPUTDIR/masscan/resolv.ip"
         else
-            echo -e "$(dig +short $item | grep -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | sort -u | tr -s ' ' '\n')" >> masscan/resolv.ip
-            echo -e "$(dig +short $item | grep -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\/[0-9]{1,2}' | sort -u | tr -s ' ' '\n')" >> masscan/resolv.ip
+            echo -e "$(dig +short $item | grep -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | sort -u | tr -s ' ' '\n')" >> "$OUTPUTDIR/masscan/resolv.ip"
+            echo -e "$(dig +short $item | grep -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\/[0-9]{1,2}' | sort -u | tr -s ' ' '\n')" >> "$OUTPUTDIR/masscan/resolv.ip"
         fi
     done
 }
 
 massscanPortScan(){
-    MAXRATE=
-    if  [[ -z "$MAXRATE" ]]; then
-        read -p "[!] Set Masscans value for --max-rate (500): " MAXRATE
-    fi
-    if [[ -z "$MAXRATE" ]];
+    masscanResolver
+    if [ ! -z "$MASSCANINTERFACE" ]
     then
-        MAXRATE=500
+        MASSCANINTERFACE="--interface ${MASSCANINTERFACE} "
     fi
-    echo -e "\n[+] ${BOLD}Masscan Starting"
     echo -e "\n[${GREEN}+${RESET}] Running a ${YELLOW}port scan${RESET} for all IPs in masscan/alive.ip"
-    masscan --open -iL masscan/resolv.ip \
-            --excludefile exclude.ip \
-            -oG masscan/scans/$PORTRANGE.gnmap -v \
-            -p $PORTRANGE \
+    masscan --open -iL "$OUTPUTDIR/masscan/resolv.ip" \
+            --excludefile exclude.ip $MASSCANINTERFACE\
+            -oG "$OUTPUTDIR/masscan/scans/masscan.gnmap" -v \
+            -p "$TCPPORTRANGE,U:$UDPPORTRANGE" \
             --max-rate=$MAXRATE
 }
 
@@ -65,8 +40,8 @@ pingSweep(){
     echo -e "\n[${GREEN}+${RESET}] Running ${YELLOW}nmap${RESET} scans"
     echo -e "\n[${GREEN}+${RESET}] Running an ${YELLOW}nmap ping sweep${RESET} for all ip in targets.ip"
     nmap --open -sn -PE -iL targets.ip \
-         -oA nmap/scans/PingSweep --excludefile exclude.ip --min-hostgroup $MINHOST --min-rate=$MINRATE
-    grep "Up" nmap/scans/PingSweep.gnmap | cut -d " " -f2 | sort -u > nmap/alive.ip
+         -oA "$OUTPUTDIR/nmap/scans/PingSweep" --excludefile exclude.ip --min-hostgroup $MINHOST --min-rate=$MINRATE
+    grep "Up" "$OUTPUTDIR/nmap/scans/PingSweep.gnmap" | cut -d " " -f2 | sort -u > "$OUTPUTDIR/nmap/alive.ip"
 }
 
 # nmap pingsweep with --min-rate & --min-hostgroup pre-configured
@@ -74,24 +49,24 @@ pingSweepDefault(){
     echo -e "\n[${GREEN}+${RESET}] Running ${YELLOW}nmap${RESET} scans"
     echo -e "\n[${GREEN}+${RESET}] Running an ${YELLOW}nmap ping sweep${RESET} for all ip in targets.ip"
     nmap --open -sn -PE -iL targets.ip \
-         -oA nmap/scans/PingSweep --excludefile exclude.ip --min-hostgroup 50 --min-rate=200
-    grep "Up" nmap/scans/PingSweep.gnmap | cut -d " " -f2 | sort -u > nmap/alive.ip
+         -oA "$OUTPUTDIR/nmap/scans/PingSweep" --excludefile exclude.ip --min-hostgroup 50 --min-rate=200
+    grep "Up" "$OUTPUTDIR/nmap/scans/PingSweep.gnmap" | cut -d " " -f2 | sort -u > "$OUTPUTDIR/nmap/alive.ip"
 }
 
 # regardless of host being 'Up' from a pingsweep, run a portscan of all targets
 nmapAllHostsPortScan(){
     echo -e "\n[${GREEN}+${RESET}] Running an ${YELLOW}nmap port scan${RESET} for all ip in nmap/alive.ip"
     nmap --open -iL targets.ip \
-         -sU -sS -sV -O -Pn -n -oA nmap/scans/portscan -v \
-         -p T:$PORTRANGE,U:53,69,123,161,500,1434 \
+         -sU -sS -sV -O -Pn -n -oA "$OUTPUTDIR/nmap/scans/portscan" -v \
+         -p T:$TCPPORTRANGE,U:$UDPPORTRANGE \
          --min-hostgroup $MINHOST --min-rate=$MINRATE
 }
 
 #only scan targets that responded to an ICMP pingsweep
 nmapPortScan(){
     echo -e "\n[${GREEN}+${RESET}] Running an ${YELLOW}nmap port scan${RESET} for all ip in nmap/alive.ip"
-    nmap --open -iL nmap/alive.ip \
-         -sU -sS -sV -O -Pn -n -oA nmap/scans/portscan -v \
-         -p T:$PORTRANGE,U:53,69,123,161,500,1434 \
+    nmap --open -iL "$OUTPUTDIR/nmap/alive.ip" \
+         -sU -sS -sV -O -Pn -n -oA "$OUTPUTDIR/nmap/scans/portscan" -v \
+         -p T:$TCPPORTRANGE,U:$UDPPORTRANGE \
          --min-hostgroup $MINHOST --min-rate=$MINRATE
 }

--- a/getopts-long.sh
+++ b/getopts-long.sh
@@ -1,0 +1,69 @@
+# Taken from https://gist.github.com/nicowilliams/f3fe2b10b380aecdef403acb246dced2
+# getopts_long long_opts_assoc_array_name optstring optname args...
+#
+#   long_opts_assoc_array_name is the name of an associative array whose
+#   indices are long option names and whose values are either the empty
+#   string (option takes no argument) or : (option takes an argument).
+#
+#   optstring is an optstring value for getopts
+#
+#   optname is the name of a variable in which to put the matched option
+#   name / letter.
+#
+#   args... is the arguments to parse.
+#
+# As with getopts, $OPTIND is set to the next argument to check at the
+# next invocation.  Unset OPTIND or set it to 1 to reset options
+# processing.
+#
+# As with getopts, "--" is a special argument that ends options
+# processing.
+#
+function getopts_long {
+    if (($# < 3)); then
+        printf 'bash: illegal use of getopts_long\n'
+        printf 'Usage: getopts_long lvar optstring name [ARGS]\n'
+        printf '\t{lvar} is the name of an associative array variable\n'
+        printf '\twhose keys are long option names and values are\n'
+        printf '\tthe empty string (no argument) or ":" (argument\n'
+        printf '\trequired).\n\n'
+        printf '\t{optstring} and {name} are as for the {getopts}\n'
+        printf '\tbash builtin.\n'
+        return 1
+    fi 1>&2
+    [[ ${1:-} != largs ]] && local -n largs="$1"
+    local optstr="$2"
+    [[ ${3:-} != opt ]] && local -n opt="$3"
+    local optvar="$3"
+    shift 3
+
+    OPTARG=
+    : "${OPTIND:=1}"
+    opt=${@:$OPTIND:1}
+    if [[ $opt = -- ]]; then
+        opt='?'
+        return 1
+    fi
+    if [[ $opt = --* ]]; then
+        local optval=false
+        opt=${opt#--}
+        if [[ $opt = *=* ]]; then
+            OPTARG=${opt#*=}
+            opt=${opt%%=*}
+            optval=true
+        fi
+        ((++OPTIND))
+        if [[ ${largs[$opt]+yes} != yes ]]; then
+            ((OPTERR)) && printf 'bash: illegal long option %s\n' "$opt" 1>&2
+            return 0
+        fi
+        if [[ ${largs[$opt]:-} = : ]]; then
+            if ! $optval; then
+                OPTARG=${@:$OPTIND:1}
+                ((++OPTIND))
+            fi
+        fi
+        return 0
+    fi
+    getopts "$optstr" "$optvar" "$@"
+}

--- a/nmap-nse-scans.sh
+++ b/nmap-nse-scans.sh
@@ -1,191 +1,191 @@
 #!/bin/bash
 nse(){
     echo -e "\n[${GREEN}+${RESET}] running ${YELLOW}nse${RESET} scans"
-    if [ -f open-ports/21.txt ]; 
+    if [ -f "$OUTPUTDIR/open-ports/21.txt" ]; 
     then
 	echo -e "\n[${GREEN}+${RESET}] running scans for port ${YELLOW}21${RESET}"
-	nmap -sC -sV -p 21 -iL open-ports/21.txt \
-	     --script=ftp-anon,ftp-bounce,ftp-proftpd-backdoor,ftp-vsftpd-backdoor -oN nse_scans/ftp.txt \
+	nmap -sC -sV -p 21 -iL "$OUTPUTDIR/open-ports/21.txt" \
+	     --script=ftp-anon,ftp-bounce,ftp-proftpd-backdoor,ftp-vsftpd-backdoor -oN "nse_scans/ftp.txt" \
 	     --stats-every 60s --min-hostgroup $MINHOST --min-rate=$MINRATE
     else
 	:
     fi
-    if [ -f open-ports/22.txt ];
+    if [ -f "$OUTPUTDIR/open-ports/22.txt" ];
     then
 	echo -e "\n[${GREEN}+${RESET}] running scans for port ${YELLOW}22${RESET}"
-	nmap -sC -sV -p 22 -iL open-ports/22.txt \
-	     --script=ssh2-enum-algos -oN nse_scans/ssh.txt \
+	nmap -sC -sV -p 22 -iL "$OUTPUTDIR/open-ports/22.txt" \
+	     --script=ssh2-enum-algos -oN "$OUTPUTDIR/nse_scans/ssh.txt" \
 	     --stats-every 60s --min-hostgroup $MINHOST --min-rate=$MINRATE
     else
 	:
     fi
-    if [ -f open-ports/23.txt ];
+    if [ -f "$OUTPUTDIR/open-ports/23.txt" ];
     then
 	echo -e "\n[${GREEN}+${RESET}] running scans for port ${YELLOW}23${RESET}"
-	nmap -sC -sV -p 23 -iL open-ports/23.txt \
-	     --script=telnet-encryption,banner,telnet-ntlm-info,tn3270-info -oN nse_scans/telnet.txt \
+	nmap -sC -sV -p 23 -iL "$OUTPUTDIR/open-ports/23.txt" \
+	     --script=telnet-encryption,banner,telnet-ntlm-info,tn3270-info -oN "$OUTPUTDIR/nse_scans/telnet.txt" \
 	     --stats-every 60s --min-hostgroup $MINHOST --min-rate=$MINRATE
     else
 	:
     fi
-    if [ -f open-ports/25.txt ];
+    if [ -f "$OUTPUTDIR/open-ports/25.txt" ];
     then
 	echo -e "\n[${GREEN}+${RESET}] running scans for port ${YELLOW}25${RESET}"
-	nmap -sC -sV -p 25 -iL open-ports/25.txt \
+	nmap -sC -sV -p 25 -iL "$OUTPUTDIR/open-ports/25.txt" \
 	     --script=smtp-commands,smtp-open-relay,smtp-ntlm-info,smtp-enum-users.nse \
-	     --script-args smtp-enum-users.methods={EXPN,VRFY} -oN nse_scans/smtp.txt \
+	     --script-args smtp-enum-users.methods={EXPN,VRFY} -oN "$OUTPUTDIR/nse_scans/smtp.txt" \
 	     --stats-every 60s --min-hostgroup $MINHOST --min-rate=$MINRATE
     else
 	:
     fi
-    if [ -f open-ports/53.txt ];
+    if [ -f "$OUTPUTDIR/open-ports/53.txt" ];
     then
 	echo -e "\n[${GREEN}+${RESET}] running scans for port ${YELLOW}53${RESET}"
-	nmap -sU -p 53 -iL open-ports/53.txt \
+	nmap -sU -p 53 -iL "$OUTPUTDIR/open-ports/53.txt" \
 	     --script=dns-recursion,dns-service-discovery,dns-cache-snoop.nse,dns-nsec-enum \
-	     --script-args dns-nsec-enum.domains=example.com -oN nse_scans/dns.txt \
+	     --script-args dns-nsec-enum.domains=example.com -oN "$OUTPUTDIR/nse_scans/dns.txt" \
 	     --stats-every 60s --min-hostgroup $MINHOST --min-rate=$MINRATE
     else
 	:
     fi
-    if [ -f open-ports/80.txt ];
+    if [ -f "$OUTPUTDIR/open-ports/80.txt" ];
     then
 	echo -e "\n[${GREEN}+${RESET}] running scans for port ${YELLOW}80${RESET}"
-	nmap -sC -sV -p 80 -iL open-ports/80.txt \
+	nmap -sC -sV -p 80 -iL "$OUTPUTDIR/open-ports/80.txt" \
 	     --script=http-default-accounts,http-enum,http-title,http-methods,http-robots.txt,http-trace,http-shellshock,http-dombased-xss,http-phpself-xss,http-wordpress-enum,http-wordpress-users \
-	     -oN nse_scans/http.txt \
+	     -oN "$OUTPUTDIR/nse_scans/http.txt" \
 	     --stats-every 60s --min-hostgroup $MINHOST --min-rate=$MINRATE
     else
 	:
     fi
-    if [ -f open-ports/110.txt ];
+    if [ -f "$OUTPUTDIR/open-ports/110.txt" ];
     then
 	echo -e "\n[${GREEN}+${RESET}] running scans for port ${YELLOW}110${RESET}"
-	nmap -sC -sV -p 110 -iL open-ports/110.txt \
-	     --script=pop3-capabilities -oN nse_scans/pop3.txt \
+	nmap -sC -sV -p 110 -iL "$OUTPUTDIR/open-ports/110.txt" \
+	     --script=pop3-capabilities -oN "$OUTPUTDIR/nse_scans/pop3.txt" \
 	     --stats-every 60s --min-hostgroup $MINHOST --min-rate=$MINRATE
     else
 	:
     fi
-    if [ -f open-ports/111.txt ];
+    if [ -f "$OUTPUTDIR/open-ports/111.txt" ];
     then
 	echo -e "\n[${GREEN}+${RESET}] running scans for port ${YELLOW}111${RESET}"
-	nmap -sV -p 111 -iL open-ports/111.txt \
-	     --script=nfs-showmount,nfs-ls -oN nse_scans/nfs111.txt \
+	nmap -sV -p 111 -iL "$OUTPUTDIR/open-ports/111.txt" \
+	     --script=nfs-showmount,nfs-ls -oN "$OUTPUTDIR/nse_scans/nfs111.txt" \
 	     --stats-every 60s --min-hostgroup $MINHOST --min-rate=$MINRATE
     else
 	:
     fi
-    if [ -f open-ports/123.txt ];
+    if [ -f "$OUTPUTDIR/open-ports/123.txt" ];
     then
 	echo -e "\n[${GREEN}+${RESET}] running scans for port ${YELLOW}123${RESET}"
-	nmap -sU -p 123 -iL open-ports/123.txt \
-	     --script=ntp-info,ntp-monlist -oN nse_scans/ntp.txt \
+	nmap -sU -p 123 -iL "$OUTPUTDIR/open-ports/123.txt" \
+	     --script=ntp-info,ntp-monlist -oN "$OUTPUTDIR/nse_scans/ntp.txt" \
 	     --stats-every 60s --min-hostgroup $MINHOST --min-rate=$MINRATE
     else
 	:
     fi
-    if [ -f open-ports/161.txt ];
+    if [ -f "$OUTPUTDIR/open-ports/161.txt" ];
     then
 	echo -e "\n[${GREEN}+${RESET}] running scans for port ${YELLOW}161${RESET}"
-	nmap -sC -sU -p 161 -iL open-ports/161.txt \
-	     --script=snmp-interfaces,snmp-sysdescr,snmp-netstat,snmp-processes -oN nse_scans/snmp.txt \
+	nmap -sC -sU -p 161 -iL "$OUTPUTDIR/open-ports/161.txt" \
+	     --script=snmp-interfaces,snmp-sysdescr,snmp-netstat,snmp-processes -oN "$OUTPUTDIR/nse_scans/snmp.txt" \
 	     --stats-every 60s --min-hostgroup $MINHOST --min-rate=$MINRATE
     else
 	:
     fi
-    if [ -f open-ports/443.txt ];
+    if [ -f "$OUTPUTDIR/open-ports/443.txt" ];
     then
 	echo -e "\n[${GREEN}+${RESET}] running scans for port ${YELLOW}443${RESET}"
-	nmap -sC -sV -p 443 -iL open-ports/443.txt \
+	nmap -sC -sV -p 443 -iL "$OUTPUTDIR/open-ports/443.txt" \
 	     --script=http-default-accounts,http-title,http-methods,http-robots.txt,http-trace,http-shellshock,http-dombased-xss,http-phpself-xss,http-wordpress-enum \
-	     -oN nse_scans/https.txt \
+	     -oN "$OUTPUTDIR/nse_scans/https.txt" \
 	     --stats-every 60s --min-hostgroup $MINHOST --min-rate=$MINRATE
 
-	nmap -sC -sV -p 443 -iL open-ports/443.txt --version-light \
+	nmap -sC -sV -p 443 -iL "$OUTPUTDIR/open-ports/443.txt" --version-light \
 	 --script=ssl-poodle,ssl-heartbleed,ssl-enum-ciphers,ssl-cert-intaddr \
-	 --script-args vulns.showall -oN nse_scans/ssl.txt \
+	 --script-args vulns.showall -oN "$OUTPUTDIR/nse_scans/ssl.txt" \
 	 --stats-every 60s --min-hostgroup $MINHOST --min-rate=$MINRATE
     else
 	:
     fi
-    if [ -f open-ports/445.txt ];
+    if [ -f "$OUTPUTDIR/open-ports/445.txt" ];
     then
 	echo -e "\n[${GREEN}+${RESET}] running scans for port ${YELLOW}445${RESET}"
-	nmap -sC -sV  -p 445 -iL open-ports/445.txt \
+	nmap -sC -sV  -p 445 -iL "$OUTPUTDIR/open-ports/445.txt" \
 	     --script=smb-enum-shares.nse,smb-os-discovery.nse,smb-enum-users.nse,smb-security-mode,smb-vuln-ms17-010,smb-vuln-ms08-067,smb2-vuln-uptime \
-	     -oN nse_scans/smb.txt \
+	     -oN "$OUTPUTDIR/nse_scans/smb.txt" \
 	     --stats-every 60s --min-hostgroup $MINHOST --min-rate=$MINRATE
     else
 	:
     fi
-    if [ -f open-ports/1521.txt ];
+    if [ -f "$OUTPUTDIR/open-ports/1521.txt" ];
     then
-	nmap -p 1521-1560 -iL open-ports/1521.txt \
-	     --script=oracle-sid-brute -oN nse_scans/oracle.txt \
+	nmap -p 1521-1560 -iL "$OUTPUTDIR/open-ports/1521.txt" \
+	     --script=oracle-sid-brute -oN "$OUTPUTDIR/nse_scans/oracle.txt" \
 	     --stats-every 60s --min-hostgroup $MINHOST --min-rate=$MINRATE
     else
 	:
     fi
-    if [ -f open-ports/2049.txt ];
+    if [ -f "$OUTPUTDIR/open-ports/2049.txt" ];
     then
-	nmap -sV -p 2049 -iL open-ports/2049.txt \
-	     --script=nfs-showmount,nfs-ls -oN nse_scans/nfs2049.txt \
+	nmap -sV -p 2049 -iL "$OUTPUTDIR/open-ports/2049.txt" \
+	     --script=nfs-showmount,nfs-ls -oN "$OUTPUTDIR/nse_scans/nfs2049.txt" \
 	     --stats-every 60s --min-hostgroup $MINHOST --min-rate=$MINRATE
     else
 	:
     fi
-    if [ -f open-ports/3306.txt ];
+    if [ -f "$OUTPUTDIR/open-ports/3306.txt" ];
     then
 	echo -e "\n[${GREEN}+${RESET}] running scans for port ${YELLOW}3306${RESET}"
-	nmap -sC -sV -p 3306 -iL open-ports/3306.txt \
+	nmap -sC -sV -p 3306 -iL "$OUTPUTDIR/open-ports/3306.txt" \
 	     --script=mysql-empty-password,mysql-users,mysql-enum,mysql-audit \
 	     --script-args "mysql-audit.username='root', \mysql-audit.password='foobar',mysql-audit.filename='nselib/data/mysql-cis.audit'" \
-	     -oN nse_scans/mysql.txt \
+	     -oN "$OUTPUTDIR/nse_scans/mysql.txt" \
 	     --stats-every 60s --min-hostgroup $MINHOST --min-rate=$MINRATE
     
-	nmap -sC -sV -p 3306 -iL open-ports/3306.txt \
+	nmap -sC -sV -p 3306 -iL "$OUTPUTDIR/open-ports/3306.txt" \
 	     --script=mysql-empty-password,mysql-users,mysql-enum,mysql-audit \
 	     --script-args "mysql-audit.username='root', \mysql-audit.password='foobar',mysql-audit.filename='nselib/data/mysql-cis.audit'" \
-	     -oN nse_scans/mysql.txt \
+	     -oN "$OUTPUTDIR/nse_scans/mysql.txt" \
 	     --stats-every 60s --min-hostgroup $MINHOST --min-rate=$MINRATE
     else
 	:
     fi
-    if [ -f open-ports/5900.txt ];
+    if [ -f "$OUTPUTDIR/open-ports/5900.txt" ];
     then
 	echo -e "\n[${GREEN}+${RESET}] running scans for port ${YELLOW}5900${RESET}"
-	nmap -sC -sV -p 5900 -iL open-ports/5900.txt \
-	     --script=banner,vnc-title -oN nse_scans/vnc.txt \
+	nmap -sC -sV -p 5900 -iL "$OUTPUTDIR/open-ports/5900.txt" \
+	     --script=banner,vnc-title -oN "$OUTPUTDIR/nse_scans/vnc.txt" \
 	     --stats-every 60s --min-hostgroup $MINHOST --min-rate=$MINRATE
     else
 	:
     fi
-    if [ -f open-ports/8080.txt ];
+    if [ -f "$OUTPUTDIR/open-ports/8080.txt" ];
     then
 	echo -e "\n[${GREEN}+${RESET}] running scans for port ${YELLOW}8080${RESET}"
-	nmap -sC -sV -p 8080 -iL open-ports/8080.txt \
+	nmap -sC -sV -p 8080 -iL "$OUTPUTDIR/open-ports/8080.txt" \
 	     --script=http-default-accounts,http-title,http-robots.txt,http-methods,http-shellshock,http-dombased-xss,http-phpself-xss \
-	     -oN nse_scans/http8080.txt \
+	     -oN "$OUTPUTDIR/nse_scans/http8080.txt" \
 	     --stats-every 60s --min-hostgroup $MINHOST --min-rate=$MINRATE
     else
 	:
     fi
-    if [ -f open-ports/8443.txt ];
+    if [ -f "$OUTPUTDIR/open-ports/8443.txt" ];
     then
 	echo -e "\n[${GREEN}+${RESET}] running scans for port ${YELLOW}8443${RESET}"
-	nmap -sC -sV -p 8443 -iL open-ports/8443.txt \
+	nmap -sC -sV -p 8443 -iL "$OUTPUTDIR/open-ports/8443.txt" \
 	     --script=http-default-accounts,http-title,http-robots.txt,http-methods,http-shellshock,http-dombased-xss,http-phpself-xss \
-	     -oN nse_scans/https8443.txt \
+	     -oN "$OUTPUTDIR/nse_scans/https8443.txt" \
 	     --stats-every 60s --min-hostgroup $MINHOST --min-rate=$MINRATE
     else
 	:
     fi
-    if [ -f open-ports/27017.txt ];
+    if [ -f "$OUTPUTDIR/open-ports/27017.txt" ];
     then
 	echo -e "\n[${GREEN}+${RESET}] running scans for port ${YELLOW}27017${RESET}"
-	nmap -sC -sV -p 27017 -iL open-ports/27017.txt \
-	     --script=mongodb-info,mongodb-databases -oN nse_scans/mongodb.txt \
+	nmap -sC -sV -p 27017 -iL "$OUTPUTDIR/open-ports/27017.txt" \
+	     --script=mongodb-info,mongodb-databases -oN "$OUTPUTDIR/nse_scans/mongodb.txt" \
 	     --stats-every 60s --min-hostgroup $MINHOST --min-rate=$MINRATE
     else
 	:
@@ -195,47 +195,47 @@ nse(){
 #-- other scans
 otherScans(){
     echo -e "\n[${GREEN}+${RESET}] running ${YELLOW}other${RESET} scans"
-    if [ -f open-ports/500.txt ];
+    if [ -f "$OUTPUTDIR/open-ports/500.txt" ];
     then
 	echo -e "\n[${GREEN}+${RESET}] running scans for port ${YELLOW}500${RESET}"
-	nmap -sU -p 500 -iL open-ports/500.txt \
-	     --script=ike-version -oN nse_scans/ike.txt \
+	nmap -sU -p 500 -iL "$OUTPUTDIR/open-ports/500.txt" \
+	     --script=ike-version -oN "$OUTPUTDIR/nse_scans/ike.txt" \
 	     --stats-every 60s --min-hostgroup $MINHOST --min-rate=$MINRATE
-	for ip in $(cat open-ports/500.txt)
+	for ip in $(cat "$OUTPUTDIR/open-ports/500.txt")
 	do	    
-	    ike-scan -A -M $ip --id=GroupVPN | tee -a nse_scans/IKE-$ip.txt
+	    ike-scan -A -M $ip --id=GroupVPN | tee -a "$OUTPUTDIR/nse_scans/IKE-$ip.txt"
 	done
     else
 	:
     fi
 
-    if [ -f open-ports/139.txt ] || [ -f open-ports/445.txt ];
+    if [ -f "$OUTPUTDIR/open-ports/139.txt" ] || [ -f "$OUTPUTDIR/open-ports/445.txt" ];
     then
 	echo -e "\n[${GREEN}+${RESET}] Running further scans for SMB ports${RESET}"
-	for ip in $(cat open-ports/139.txt)
+	for ip in $(cat "$OUTPUTDIR/open-ports/139.txt")
 	do
-	    nbtscan $ip | tee -a nse_scans/nbtscan-$ip.txt
+	    nbtscan $ip | tee -a "$OUTPUTDIR/nse_scans/nbtscan-$ip.txt"
 	done
-	for ip in $(cat open-ports/445.txt)
+	for ip in $(cat "$OUTPUTDIR/open-ports/445.txt")
 	do
-	    nbtscan $ip | tee -a nse_scans/nbtscan-$ip.txt
+	    nbtscan $ip | tee -a "$OUTPUTDIR/nse_scans/nbtscan-$ip.txt"
 	done
     else
 	:
     fi
     
-    if [ -f open-ports/443.txt ];
+    if [ -f "$OUTPUTDIR/open-ports/443.txt" ];
     then
 	echo -e "\n[${GREEN}+${RESET}] running scans for port ${YELLOW}443${RESET}"
-	for ip in $(cat open-ports/443.txt)
+	for ip in $(cat "$OUTPUTDIR/open-ports/443.txt")
 	do
 	    curl -v https://$ip/ -H "Host: hostname" \
 		 --max-time 10 \
-		 -H "Range: bytes=0-18446744073709551615" -k | tee -a nse_scans/MS15034-$ip.txt
+		 -H "Range: bytes=0-18446744073709551615" -k | tee -a "$OUTPUTDIR/nse_scans/MS15034-$ip.txt"
 	    curl -Ikv -X GET -0 \
 		 --max-time 10 \
 		 -H 'Host:' https://$ip/autodiscover/autodiscover.xml \
-		| tee -a nse_scans/internal-ip-header-check-$ip.txt
+		| tee -a "$OUTPUTDIR/nse_scans/internal-ip-header-check-$ip.txt"
 	done
     else
 	:
@@ -244,13 +244,13 @@ otherScans(){
 
 discoveryScans(){
     # These scans look to enumerate information based off of common word lists or dictionaries.
-    if [ -f open-ports/80.txt ];
+    if [ -f "$OUTPUTDIR/open-ports/80.txt" ];
     then
 	echo -e "\n[${GREEN}+${RESET}] Running world list scan for port ${YELLOW}80${RESET}"
 	echo -e "\nDirb default wordlist of 4612 words"
-	for ip in $(cat open-ports/80.txt)
+	for ip in $(cat "$OUTPUTDIR/open-ports/80.txt")
 	do
-	    dirb http://$ip | tee -a nse_scans/dirb-$ip.txt
+	    dirb http://$ip | tee -a "$OUTPUTDIR/nse_scans/dirb-$ip.txt"
 	done 
     else
 	:

--- a/parsers.sh
+++ b/parsers.sh
@@ -1,12 +1,12 @@
 #-- combining masscan and nmap results
 combiner(){
     echo -e "\n[${GREEN}+${RESET}] Combining ${YELLOW}nmap${RESET} and ${YELLOW}masscan${RESET} scans"
-    touch alive.ip
-    touch masscan/alive.ip
-    cp masscan/scans/* scans
-    cp nmap/scans/* scans
-    cat masscan/scans/$PORTRANGE.gnmap | head -n -1 | tail -n +3 | cut -d ' ' -f 2 | sort -u > masscan/alive.ip
-    cat masscan/alive.ip nmap/alive.ip | sort -u >> alive.ip
+    touch "$OUTPUTDIR/alive.ip"
+    touch "$OUTPUTDIR/masscan/alive.ip"
+    cp "$OUTPUTDIR/masscan/scans/"* "$OUTPUTDIR/scans"
+    cp "$OUTPUTDIR/nmap/scans/"* "$OUTPUTDIR/scans"
+    cat "$OUTPUTDIR/masscan/scans/masscan.gnmap" | head -n -1 | tail -n +3 | cut -d ' ' -f 3 | sort -u > "$OUTPUTDIR/masscan/alive.ip"
+    cat "$OUTPUTDIR/masscan/alive.ip" "$OUTPUTDIR/nmap/alive.ip" | sort -u >> "$OUTPUTDIR/alive.ip"
 }
 
 #progress bar
@@ -23,19 +23,19 @@ parser(){
  
     for n in $(seq $MINPORT $MAXPORT);   
     do
-	if [ $(cat scans/*.gnmap | egrep " $n\/open\/tcp/" | cut -d " " -f 2 | wc -l) -eq '0' ];
+	if [ $(cat "$OUTPUTDIR/scans/"*.gnmap | egrep " $n\/open\/tcp/" | cut -d " " -f 2 | wc -l) -eq '0' ];
 	then
 	    prog "$n" out of $MAXPORT TCP ports...
 	   # sleep .1 	
 	else
-	    cat scans/*.gnmap | egrep " $n\/open\/tcp/" | cut -d " " -f 2 >> open-ports/$n.txt
+	    cat "$OUTPUTDIR/scans/"*.gnmap | egrep " $n\/open\/tcp/" | cut -d " " -f 2 >> "$OUTPUTDIR/open-ports/$n.txt"
 	fi
-	if [ $(cat scans/*.gnmap | egrep " $n\/open\/udp/" | cut -d " " -f 2 | wc -l) -eq '0' ];
+	if [ $(cat "$OUTPUTDIR/scans/"*.gnmap | egrep " $n\/open\/udp/" | cut -d " " -f 2 | wc -l) -eq '0' ];
 	then
 	    prog "$n" out of $MAXPORT UDP ports...
 	   # sleep .1 
 	else
-	    cat scans/*.gnmap | egrep " $n\/open\/udp/" | cut -d " " -f 2 >> open-ports/$n.txt
+	    cat "$OUTPUTDIR/scans/"*.gnmap | egrep " $n\/open\/udp/" | cut -d " " -f 2 >> "$OUTPUTDIR/open-ports/$n.txt"
 	fi
     done
 }
@@ -48,20 +48,22 @@ csvParser(){
 	exit 1
     else
     	wget https://raw.githubusercontent.com/TDSSEC/Nmap-Scan-to-CSV/master/nmap_xml_parser.py 
-	$(which python3) nmap_xml_parser.py -f scans/*.xml -csv host-info.csv
+	$(which python3) nmap_xml_parser.py -f "$OUTPUTDIR/scans/"*.xml -csv "$OUTPUTDIR/host-info.csv"
     fi
 }
 #-- summary
 summary(){
     echo -e "\n[${GREEN}+${RESET}] Generating a summary of the scans..."
-    for ip in $(cat ./alive.ip); do
-	echo -e $ip > ./open-ports/$ip.txt
-	awk \/$ip\/ masscan/scans/$PORTRANGE.gnmap | egrep -o '*[0-9]*/open/*[tcp/udp]*/' | sort | uniq | awk -F '/' '{print $1"/"$3}' >> ./open-ports/$ip.txt
-	awk \/$ip\/ nmap/scans/portscan.gnmap | egrep -o '*[0-9]*/open/*[tcp/udp]*/' | sort | uniq | awk -F '/' '{print $1"/"$3}' >> ./open-ports/$ip.txt
+    for ip in $(cat "$OUTPUTDIR/alive.ip"); do
+	echo -e $ip > "$OUTPUTDIR/open-ports/$ip.txt"
+	awk \/$ip\/ "$OUTPUTDIR/masscan/scans/masscan.gnmap" | egrep -o '*[0-9]*/open/*[tcp/udp]*/' | sort | uniq | awk -F '/' '{print $1"/"$3}' >> "$OUTPUTDIR/tempports.tmp"
+	awk \/$ip\/ "$OUTPUTDIR/nmap/scans/portscan.gnmap" | egrep -o '*[0-9]*/open/*[tcp/udp]*/' | sort | uniq | awk -F '/' '{print $1"/"$3}' >> "$OUTPUTDIR/tempports.tmp"
+    cat "$OUTPUTDIR/tempports.tmp" | sort -u >> "$OUTPUTDIR/open-ports/$ip.txt"
+    rm -f "$OUTPUTDIR/tempports.tmp"
     done
-    echo -e "\n[${GREEN}+${RESET}] there are $(cat ./alive.ip | wc -l ) ${YELLOW}alive hosts${RESET} and $(egrep -o '[0-9]*/open/' scans/*.gnmap | cut -d ':' -f 2 | sort | uniq | wc -l) ${YELLOW}unique ports/services${RESET}" | tee -a discovered_ports.txt
+    echo -e "\n[${GREEN}+${RESET}] there are $(cat "$OUTPUTDIR/alive.ip" | wc -l ) ${YELLOW}alive hosts${RESET} and $(egrep -o '[0-9]*/open/*[tcp/udp]*/' "$OUTPUTDIR/scans/"*.gnmap | cut -d ':' -f 2 | sort | uniq | wc -l) ${YELLOW}unique ports/services${RESET}" | tee -a "$OUTPUTDIR/discovered_ports.txt"
 }
 
 summaryPingSweep(){
-    echo -e "\n[${GREEN}+${RESET}] ${YELLOW}There are $(cat nmap/alive.ip | wc -l ) alive hosts${RESET}"
+    echo -e "\n[${GREEN}+${RESET}] ${YELLOW}There are $(cat "$OUTPUTDIR/nmap/alive.ip" | wc -l ) alive hosts${RESET}"
 }


### PR DESCRIPTION
- Updated tool checker to show all missing tools rather than just the first one
- Remove 127.0.0.1 from internal IP addresses list
- Added check to ensure that `target.ip` file is populated before running tests
- Running without arguments now shows the help screen
- Updated getopts to allow long options
- Added option to specify the network interface for masscan to use
- added new command line arguments: --tcpportrange --udpportrange --nmap-minhost --nmap-minrate --masscan-maxrate --masscan-interface --outputdir
- Script no longer asks for NMAP options. Instead, these should be specified on the command line 
- Replaced "press enter to continue" after IP addresses are displayed to a 5 second countdown timer
- Output directory is now based on the current date/time and is placed in the current directory
- Added option to specify the output directory (handy if you just want to run the nmap to CSV script)
- Fixed: You can now run the script without being in the script directory
- Fixed: masscan now scans UDP ports as well as TCP ports
- Fixed: Summary unique ports is wrong if it finds the same port open for both udp and tcp (e.g. UDP/53 and TCP/53 show as one unique port)