### PR TITLE
Use alive hosts list for nmap port scans

### DIFF
--- a/discovery_scans.py
+++ b/discovery_scans.py
@@ -198,15 +198,19 @@ def _nmap_port_command(
 
 
 def nmap_fast_port_scan(config: ScanConfig) -> None:
-    """Run an nmap TCP/UDP port scan without service or OS detection."""
+    """Run an nmap TCP/UDP port scan, preferring alive hosts without service or OS detection."""
 
+    alive_file = config.output_dir / "nmap" / "alive.ip"
+    alive_exists = alive_file.exists()
+    target = alive_file if alive_exists else config.targets_file
+    target_desc = "nmap/alive.ip" if alive_exists else "targets.ip"
     print(
         f"\n[{colour_text('+', COLOURS.green)}] Running an {colour_text('nmap port scan', COLOURS.yellow)}"
-        " for all ip in nmap/alive.ip. No version or OS detection"
+        f" for all ip in {target_desc}. No version or OS detection"
     )
     command = _nmap_port_command(
         config,
-        target_file=config.targets_file,
+        target_file=target,
         enable_version=False,
         enable_os=False,
     )
@@ -214,15 +218,19 @@ def nmap_fast_port_scan(config: ScanConfig) -> None:
 
 
 def nmap_all_hosts_port_scan(config: ScanConfig) -> None:
-    """Run an nmap port scan (including service/OS detection) against all targets."""
+    """Run an nmap port scan (including service/OS detection) against alive targets when available."""
 
+    alive_file = config.output_dir / "nmap" / "alive.ip"
+    alive_exists = alive_file.exists()
+    target = alive_file if alive_exists else config.targets_file
+    target_desc = "nmap/alive.ip" if alive_exists else "targets.ip"
     print(
         f"\n[{colour_text('+', COLOURS.green)}] Running an {colour_text('nmap port scan', COLOURS.yellow)}"
-        " for all ip in nmap/alive.ip"
+        f" for all ip in {target_desc}"
     )
     command = _nmap_port_command(
         config,
-        target_file=config.targets_file,
+        target_file=target,
         enable_version=True,
         enable_os=True,
     )

--- a/tests/test_discovery_scans.py
+++ b/tests/test_discovery_scans.py
@@ -1,0 +1,64 @@
+"""Tests for discovery scan helpers."""
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import discovery_scans
+from config import ScanConfig
+
+
+def _make_config(tmp_path: Path) -> ScanConfig:
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    (output_dir / "nmap").mkdir()
+    targets_file = tmp_path / "targets.ip"
+    targets_file.write_text("192.0.2.1\n")
+    exclude_file = tmp_path / "exclude.ip"
+    exclude_file.write_text("198.51.100.1\n")
+    return ScanConfig(
+        output_dir=output_dir,
+        targets_file=targets_file,
+        exclude_file=exclude_file,
+        tcp_port_range="1-1024",
+        udp_port_range="1-1024",
+        nmap_min_host=1,
+        nmap_min_rate=10,
+        masscan_max_rate=1000,
+        masscan_interface=None,
+    )
+
+
+def test_nmap_fast_port_scan_prefers_alive_list(tmp_path, monkeypatch):
+    config = _make_config(tmp_path)
+    alive_file = config.output_dir / "nmap" / "alive.ip"
+    alive_file.write_text("203.0.113.1\n")
+    captured: dict[str, list[str]] = {}
+
+    def fake_run_command(command):
+        captured["command"] = command
+
+    monkeypatch.setattr(discovery_scans, "run_command", fake_run_command)
+
+    discovery_scans.nmap_fast_port_scan(config)
+
+    assert str(alive_file) == captured["command"][3]
+
+
+def test_nmap_all_hosts_port_scan_falls_back_without_alive(tmp_path, monkeypatch):
+    config = _make_config(tmp_path)
+    alive_file = config.output_dir / "nmap" / "alive.ip"
+    if alive_file.exists():
+        alive_file.unlink()
+    captured: dict[str, list[str]] = {}
+
+    def fake_run_command(command):
+        captured["command"] = command
+
+    monkeypatch.setattr(discovery_scans, "run_command", fake_run_command)
+
+    discovery_scans.nmap_all_hosts_port_scan(config)
+
+    assert str(config.targets_file) == captured["command"][3]


### PR DESCRIPTION
## Summary
- prefer the generated nmap alive host list for fast and full port scans
- update console messaging to reflect the selected target list
- add pytest coverage confirming the alive list is chosen when available

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9b77e457083288746ab38f5057c40