### PR TITLE
Add missing CLI options for Nessus and NSE configuration

### DIFF
--- a/aio_enum.py
+++ b/aio_enum.py
@@ -7,6 +7,7 @@ import datetime as dt
 import os
 import sys
 import time
+import socket
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -98,7 +99,7 @@ def ip_checker() -> None:
     try:
         with urllib.request.urlopen("https://ifconfig.me/ip", timeout=5) as response:
             pub_ip = response.read().decode().strip()
-    except (urllib.error.URLError, TimeoutError):
+    except (urllib.error.URLError, socket.timeout):
         pub_ip = "Unavailable"
     print(f"\nYour Public IP is: {colour_text(pub_ip or 'Unavailable', COLOURS.red)}")
 
@@ -146,6 +147,12 @@ def parse_arguments(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--masscan-maxrate", type=int, default=500, help="Maximum rate for masscan")
     parser.add_argument("--masscan-interface", help="Network interface that masscan should use")
     parser.add_argument("--outputdir", help="Output directory for all files")
+    parser.add_argument("--nessus-file", help="Path to a Nessus report for correlation")
+    parser.add_argument(
+        "--allow-unsafe-nse",
+        action="store_true",
+        help="Enable intrusive NSE script allowlist",
+    )
     return parser.parse_args(argv)
 
 
@@ -178,6 +185,8 @@ def build_config(args: argparse.Namespace) -> Tuple[ScanConfig, str]:
         nmap_min_rate=args.nmap_minrate,
         masscan_max_rate=args.masscan_maxrate,
         masscan_interface=args.masscan_interface,
+        nessus_file=nessus_file,
+        allow_unsafe_nse=args.allow_unsafe_nse,
     )
     scantype = args.scantype or "help"
     return config, scantype

--- a/config.py
+++ b/config.py
@@ -19,4 +19,6 @@ class ScanConfig:
     nmap_min_rate: int
     masscan_max_rate: int
     masscan_interface: str | None
+    nessus_file: Path | None = None
+    allow_unsafe_nse: bool = False
 


### PR DESCRIPTION
## Summary
- add CLI flags to configure Nessus correlation and unsafe NSE behaviour
- persist the new options on ScanConfig so downstream modules can read them
- harden the IP checker to handle socket timeouts when fetching the public IP

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68da50642fdc8328abec7bd11db54397