### PR TITLE
Expand optional service validation workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ nmap
 ike-scan
 nbtscan
 dirb
+hping3
 xsltproc
 ```
 ### Setup
@@ -89,6 +90,10 @@ options:
                         Network interface that masscan should use
   --outputdir OUTPUTDIR
                         Output directory for all files
+  --nessus-file NESSUS_FILE
+                        Path to a Nessus report for correlation
+  --allow-unsafe-nse    Enable intrusive NSE script allowlist
+  --validate-services   Run extended service validation and enumeration tasks
 
 ```
 

--- a/aio_enum.py
+++ b/aio_enum.py
@@ -22,7 +22,12 @@ from discovery_scans import (
     nmap_settings,
     ping_sweep,
 )
-from nmap_nse_scans import discovery_scans, nse, other_scans
+from nmap_nse_scans import (
+    discovery_scans,
+    nse,
+    other_scans,
+    service_validation,
+)
 from parsers import (
     combiner,
     csv_parser,
@@ -44,6 +49,7 @@ TOOLS = [
     "ike-scan",
     "nbtscan",
     "dirb",
+    "hping3",
     "xsltproc",
 ]
 
@@ -153,6 +159,11 @@ def parse_arguments(argv: list[str]) -> argparse.Namespace:
         action="store_true",
         help="Enable intrusive NSE script allowlist",
     )
+    parser.add_argument(
+        "--validate-services",
+        action="store_true",
+        help="Run extended service validation and enumeration tasks",
+    )
     return parser.parse_args(argv)
 
 
@@ -187,6 +198,7 @@ def build_config(args: argparse.Namespace) -> Tuple[ScanConfig, str]:
         masscan_interface=args.masscan_interface,
         nessus_file=nessus_file,
         allow_unsafe_nse=args.allow_unsafe_nse,
+        validate_services=args.validate_services,
     )
     scantype = args.scantype or "help"
     return config, scantype
@@ -228,6 +240,8 @@ def execute_scans(config: ScanConfig, scantype: str) -> None:
     if scantype in {"scans", "all", "nmap"}:
         nse(config)
         other_scans(config)
+    if config.validate_services:
+        service_validation(config)
     if scantype == "all":
         discovery_scans(config)
 

--- a/config.py
+++ b/config.py
@@ -21,4 +21,5 @@ class ScanConfig:
     masscan_interface: str | None
     nessus_file: Path | None = None
     allow_unsafe_nse: bool = False
+    validate_services: bool = False
 

--- a/nmap_nse_scans.py
+++ b/nmap_nse_scans.py
@@ -2,6 +2,8 @@
 """Nmap NSE and auxiliary scans implemented in Python."""
 from __future__ import annotations
 
+import socket
+from contextlib import closing
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Sequence
@@ -53,6 +55,47 @@ def _run_nmap_task(config: ScanConfig, task: NmapTask) -> None:
         f"--min-rate={config.nmap_min_rate}",
     ]
     run_command(command)
+
+
+def _write_command_output(path: Path, command: Sequence[str], result) -> None:
+    """Persist the executed command and captured output to ``path``."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        handle.write(f"# Command: {' '.join(command)}\n")
+        handle.write(f"# Exit status: {result.returncode}\n\n")
+        if result.stdout:
+            handle.write(result.stdout)
+        if result.stderr:
+            if result.stdout:
+                handle.write("\n")
+            handle.write("# stderr:\n")
+            handle.write(result.stderr)
+
+
+def _capture_banner(host: str, port: int, *, timeout: float = 5.0) -> str:
+    """Return a short banner from *host*:*port*, if available."""
+
+    max_bytes = 4096
+    data = bytearray()
+    try:
+        with closing(socket.create_connection((host, port), timeout=timeout)) as sock:
+            sock.settimeout(timeout)
+            while len(data) < max_bytes:
+                try:
+                    chunk = sock.recv(max_bytes - len(data))
+                except socket.timeout:
+                    break
+                if not chunk:
+                    break
+                data.extend(chunk)
+                if len(chunk) < max_bytes - len(data):
+                    break
+    except OSError as exc:  # pragma: no cover - network dependent
+        return f"Failed to capture banner: {exc}\n"
+    if not data:
+        return "No banner captured before timeout.\n"
+    return data.decode(errors="replace")
 
 
 def nse(config: ScanConfig) -> None:
@@ -436,6 +479,137 @@ def other_scans(config: ScanConfig) -> None:
             with ad_file.open("a", encoding="utf-8") as handle:
                 handle.write(autodiscover.stdout)
                 handle.write(autodiscover.stderr)
+
+
+def service_validation(config: ScanConfig) -> None:
+    """Execute extended service validation tasks when requested."""
+
+    open_ports_dir = config.output_dir / "open-ports"
+    output_dir = config.output_dir / "nse_scans"
+    alive_hosts_path = config.output_dir / "nmap" / "alive.ip"
+
+    icmp_hosts = _hosts_from_file(alive_hosts_path)
+    if icmp_hosts:
+        print(
+            f"\n[{colour_text('+', COLOURS.green)}] Checking ICMP timestamp responses",
+        )
+        for host in icmp_hosts:
+            ts_command = [
+                "hping3",
+                "--icmp",
+                "--icmp-ts",
+                "-c",
+                "3",
+                host,
+            ]
+            ts_result = run_command(ts_command, capture_output=True, check=False)
+            _write_command_output(
+                output_dir / f"icmp-timestamp-{host}.txt",
+                ts_command,
+                ts_result,
+            )
+
+    telnet_hosts = _hosts_from_file(open_ports_dir / "23.txt")
+    if telnet_hosts:
+        print(
+            f"\n[{colour_text('+', COLOURS.green)}] Validating telnet services "
+            f"{colour_text('23', COLOURS.yellow)}"
+        )
+        for host in telnet_hosts:
+            banner = _capture_banner(host, 23)
+            banner_file = output_dir / f"telnet-banner-{host}.txt"
+            banner_file.parent.mkdir(parents=True, exist_ok=True)
+            with banner_file.open("w", encoding="utf-8") as handle:
+                handle.write(f"# Telnet banner capture for {host}:23\n")
+                handle.write(banner)
+
+    ssh_hosts = _hosts_from_file(open_ports_dir / "22.txt")
+    if ssh_hosts:
+        print(
+            f"\n[{colour_text('+', COLOURS.green)}] Enumerating SSH authentication methods "
+            f"{colour_text('22', COLOURS.yellow)}"
+        )
+        hosts_file = open_ports_dir / "22.txt"
+        auth_command = [
+            "nmap",
+            "-Pn",
+            "-p22",
+            "--script",
+            "ssh-auth-methods",
+            "-iL",
+            str(hosts_file),
+        ]
+        auth_result = run_command(auth_command, capture_output=True, check=False)
+        _write_command_output(output_dir / "ssh-auth-methods.txt", auth_command, auth_result)
+
+        for host in ssh_hosts:
+            algo_command = [
+                "nmap",
+                "-Pn",
+                "-p22",
+                "--script",
+                "ssh-enum-algos",
+                host,
+            ]
+            algo_result = run_command(algo_command, capture_output=True, check=False)
+            _write_command_output(
+                output_dir / f"ssh-enum-algos-{host}.txt",
+                algo_command,
+                algo_result,
+            )
+
+    ssl_ports = {"443": "https", "8443": "https-alt", "9443": "https-alt"}
+    for port, label in ssl_ports.items():
+        hosts = _hosts_from_file(open_ports_dir / f"{port}.txt")
+        if not hosts:
+            continue
+        print(
+            f"\n[{colour_text('+', COLOURS.green)}] Enumerating SSL/TLS ciphers for "
+            f"{colour_text(port, COLOURS.yellow)} ({label})"
+        )
+        hosts_file = open_ports_dir / f"{port}.txt"
+        ssl_command = [
+            "nmap",
+            "-Pn",
+            "-p",
+            port,
+            "--script",
+            "ssl-enum-ciphers,ssl-cert,ssl-cert-intaddr",
+            "-iL",
+            str(hosts_file),
+        ]
+        ssl_result = run_command(ssl_command, capture_output=True, check=False)
+        _write_command_output(
+            output_dir / f"ssl-enum-ciphers-{port}.txt",
+            ssl_command,
+            ssl_result,
+        )
+
+    snmp_hosts = _hosts_from_file(open_ports_dir / "161.txt")
+    if snmp_hosts:
+        print(
+            f"\n[{colour_text('+', COLOURS.green)}] Checking SNMP community strings "
+            f"{colour_text('161', COLOURS.yellow)}"
+        )
+        hosts_file = open_ports_dir / "161.txt"
+        snmp_command = [
+            "nmap",
+            "-sU",
+            "-Pn",
+            "-p161",
+            "--script",
+            "snmp-info",
+            "--script-args",
+            "snmpcommunity=public",
+            "-iL",
+            str(hosts_file),
+        ]
+        snmp_result = run_command(snmp_command, capture_output=True, check=False)
+        _write_command_output(
+            output_dir / "snmp-default-community.txt",
+            snmp_command,
+            snmp_result,
+        )
 
 
 def discovery_scans(config: ScanConfig) -> None:


### PR DESCRIPTION
## Summary
- add a `--validate-services` command-line option that propagates through the runtime configuration
- implement targeted telnet, SSH, SSL/TLS, SNMP, and ICMP timestamp validation routines when the option is enabled
- document the new workflow in the usage section of the README, including the additional hping3 prerequisite

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da91afba688328ba1c3db1ebb1389b