### PR TITLE
Normalize Nessus severity filtering

### DIFF
--- a/parsers.py
+++ b/parsers.py
@@ -14,6 +14,18 @@ from config import ScanConfig
 from utils import COLOURS, colour_text, run_command
 
 
+NESSUS_RISK_FACTOR_TO_SEVERITY = {
+    "critical": 4,
+    "high": 3,
+    "medium": 2,
+    "moderate": 2,
+    "low": 1,
+    "info": 0,
+    "informational": 0,
+    "none": 0,
+}
+
+
 def _hosts_from_file(path: Path) -> list[str]:
     if not path.exists():
         return []
@@ -252,6 +264,13 @@ def parse_nessus_report(config: ScanConfig, host_ports: dict[str, set[str]]) -> 
                 severity = int(severity_raw)
             except ValueError:
                 severity = None
+
+            if severity is None:
+                risk_factor_normalised = risk_factor.lower()
+                severity = NESSUS_RISK_FACTOR_TO_SEVERITY.get(risk_factor_normalised)
+
+            if severity is None or severity not in {1, 2, 3, 4}:
+                continue
 
             notes: list[str] = []
             if not host_alive:

--- a/tests/fixtures/sample.nessus
+++ b/tests/fixtures/sample.nessus
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<NessusClientData_v2>
+  <Report name="Example Report">
+    <ReportHost name="example.local">
+      <HostProperties>
+        <tag name="host-ip">192.0.2.10</tag>
+      </HostProperties>
+      <ReportItem port="80" protocol="tcp" svc_name="http" pluginID="100" pluginName="Informational Plugin" severity="0">
+        <risk_factor>None</risk_factor>
+      </ReportItem>
+      <ReportItem port="443" protocol="tcp" svc_name="https" pluginID="101" pluginName="Low Plugin" severity="1">
+        <risk_factor>Low</risk_factor>
+      </ReportItem>
+      <ReportItem port="22" protocol="tcp" svc_name="ssh" pluginID="102" pluginName="Medium Plugin">
+        <risk_factor>Medium</risk_factor>
+      </ReportItem>
+      <ReportItem port="25" protocol="tcp" svc_name="smtp" pluginID="103" pluginName="High Plugin" severity="3">
+        <risk_factor>High</risk_factor>
+      </ReportItem>
+      <ReportItem port="3389" protocol="tcp" svc_name="rdp" pluginID="104" pluginName="Critical Plugin" severity="4">
+        <risk_factor>Critical</risk_factor>
+      </ReportItem>
+    </ReportHost>
+  </Report>
+</NessusClientData_v2>

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,0 +1,64 @@
+"""Tests for parsers helpers."""
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from config import ScanConfig
+from parsers import parse_nessus_report
+
+
+def _make_config(tmp_path: Path, nessus_file: Path) -> ScanConfig:
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    (output_dir / "alive.ip").write_text("192.0.2.10\n")
+
+    targets_file = tmp_path / "targets.ip"
+    targets_file.write_text("192.0.2.10\n")
+    exclude_file = tmp_path / "exclude.ip"
+    exclude_file.write_text("")
+
+    return ScanConfig(
+        output_dir=output_dir,
+        targets_file=targets_file,
+        exclude_file=exclude_file,
+        tcp_port_range="1-1024",
+        udp_port_range="1-1024",
+        nmap_min_host=1,
+        nmap_min_rate=10,
+        masscan_max_rate=1000,
+        masscan_interface=None,
+        nessus_file=nessus_file,
+    )
+
+
+def test_parse_nessus_report_filters_informational(tmp_path):
+    fixture = Path(__file__).parent / "fixtures" / "sample.nessus"
+    config = _make_config(tmp_path, fixture)
+
+    host_ports = {"192.0.2.10": {"22/tcp", "25/tcp", "3389/tcp", "443/tcp"}}
+
+    parse_nessus_report(config, host_ports)
+
+    output_dir = config.output_dir / "nessus"
+    json_path = output_dir / "nessus-findings.json"
+    csv_path = output_dir / "nessus-findings.csv"
+
+    data = json.loads(json_path.read_text())
+    assert {finding["plugin_id"] for finding in data} == {"101", "102", "103", "104"}
+
+    severity_by_plugin = {finding["plugin_id"]: finding["severity"] for finding in data}
+    assert severity_by_plugin == {"101": 1, "102": 2, "103": 3, "104": 4}
+
+    with csv_path.open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+
+    assert {row["plugin_id"] for row in rows} == {"101", "102", "103", "104"}
+    for row in rows:
+        assert row["severity"] == str(severity_by_plugin[row["plugin_id"]])


### PR DESCRIPTION
## Summary
- normalise Nessus severities using risk factor fallbacks and drop informational entries
- ensure the filtered severity value is written to exported finding data
- add regression coverage exercising the Nessus parser against informational records

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbaa36aee083289ca0fb0ce37364a6